### PR TITLE
docs: Add an extra dependency installation in readme for swag executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ process can vary, so follow the instructions for each item below!
 - [Task](https://taskfile.dev/installation/) - our development tool to quickly
   run commands that run, test, and clean files.
 
+## Extra Dependencies
+
+Install these into the backend directory
+
+1. go install github.com/swaggo/swag/cmd/swag@latest
+
 ## Before Running
 
 1. Create a .env file in the root directory with a single line:


### PR DESCRIPTION
@andrewcaplan1  @AdharshKan42 
# Description

Read me fix mentioning swagger installation, because of missing executable
![image](https://github.com/GenerateNU/Care-Wallet/assets/59743922/aff303ca-6d94-45dc-a687-73b878833034)


# How Has This Been Tested?

Adharsh was a goat of a person and was able to ensure this resolved his issue

# Checklist

- [x] I have performed a self-review of my code
- [x] I have reached out to another developer to review my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
