### PR TITLE
fix: start-carewallet.sh script now grabs the current directory. it should be placed in root of care-wallet

### DIFF
--- a/start-carewallet.sh
+++ b/start-carewallet.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+COMMAND_LIST=("task start-docker" "task start-dev" "task start-ngrok" "task start-frontend")
+
+# Get the current directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+for command in "${COMMAND_LIST[@]}"; do
+    osascript << EOF
+        tell application "Terminal"
+            activate
+            tell application "System Events" to keystroke "t" using command down
+            delay 1
+            do script "cd '${CURRENT_DIR}' && ${command}" in front tab of window 1
+        end tell
+EOF
+done


### PR DESCRIPTION
# Description

[Link to Ticket](insert the link to your ticket inside the parenthesis here)

Just added a line to the script Matt sent via slack.

# How Has This Been Tested?

Seems to work for me. No unit tests since it's just a shell script.

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have reached out to another developer to review my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
